### PR TITLE
Smooth slider events, UI runs on shadowtree.

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -57,3 +57,8 @@
 #group-list-accordion .accordion-item .list-group-item:not(:last-child) {
   margin-bottom: 1em;
 }
+
+/* Provide a way to shrink the font size in a control. Useful for the read-only mac-address field */
+.smaller-font {
+  font-size: smaller;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,13 +2,14 @@ import './App.css';
 import Navbar from './modules/navbar/Navbar';
 
 import { useDispatch } from 'react-redux';
-import { loadStateTree } from './state/reducer';
+import { loadShadowTree, loadStateTree } from './state/reducer';
 import PanelGroupList from './modules/group_list/GroupList';
 import PanelSettingsModal from './modules/panel_settings/PanelSettingsModal';
 import GroupSettingsModal from './modules/panel_settings/GroupSettingsModal';
 
 function App() {
   const dispatch = useDispatch();
+  loadShadowTree(dispatch);
   loadStateTree(dispatch);
 
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -37,10 +37,14 @@ function makeApiEndpoint(target) {
 
 }
 
+export function getShadowTree() {
+  return fetchGET(makeApiEndpoint("shadowtree"));
+}
+
 export function getStateTree() {
   return fetchGET(makeApiEndpoint("statetree"));
 }
 
 export function applyProposedPanelConfig(previousPanelConfig, proposedPanelConfig) {
-  fetchPOST(makeApiEndpoint("panel"), {previousPanelConfig, proposedPanelConfig});
+  return fetchPOST(makeApiEndpoint("panel"), {previousPanelConfig, proposedPanelConfig});
 }

--- a/frontend/src/modules/group_list/GroupList.js
+++ b/frontend/src/modules/group_list/GroupList.js
@@ -58,12 +58,12 @@ function PanelGroup(groupConfig, groupName, dispatch) {
 }
 
 function PanelGroupList() {
-  const statetree = useSelector((state) => state.statetree);
+  const shadowtree = useSelector((state) => state.shadowtree);
   const dispatch = useDispatch();
 
   return (
     <div className='accordion' id="group-list-accordion">
-      {_.map(statetree, (config, name) => PanelGroup(config, name, dispatch))}
+      {_.map(shadowtree, (config, name) => PanelGroup(config, name, dispatch))}
     </div>
   );
 }

--- a/frontend/src/modules/panel_settings/PanelSettingsModal.js
+++ b/frontend/src/modules/panel_settings/PanelSettingsModal.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 import { updateProposedPanel, applyProposedPanel } from '../../state/reducer';
@@ -14,10 +15,23 @@ function formatMacAddress(macStr) {
   return _.toUpper(`${octet_1}:${octet_2}:${octet_3}:${octet_4}:${octet_5}:${octet_6}`);
 }
 
-function ColorField({color, proposedPanel, dispatch}) {
-  const value = _.toInteger(proposedPanel[color]*100);
-  const idString = `${color}Pct`;
-  const label = `${_.capitalize(color)} (${value})`;
+
+function _callUpdateProposal(dispatch, proposedPanel, colorName, event) {
+  return dispatch(updateProposedPanel({...proposedPanel, [colorName]: event.target.value/100}));
+}
+
+// Best to debounce this, otherwise the range input can feel a bit
+// laggy because of the overhead of processing all the change events
+// and synchronizing them to the redux state.
+let DEBOUNCE_MS = 200;
+let callUpdateProposal = _.debounce(_callUpdateProposal, DEBOUNCE_MS);
+
+
+function ColorField({colorName, proposedPanel, dispatch}) {
+  const shadowValue = _.toInteger(proposedPanel[colorName]*100);
+  const idString = `${colorName}Pct`;
+  const [colorValue, setColorValue] = useState(shadowValue);
+  const label = `${_.capitalize(colorName)} (${colorValue})`;
   return (
     <div>
       <label htmlFor={idString} className="form-label">{label}</label>
@@ -26,15 +40,21 @@ function ColorField({color, proposedPanel, dispatch}) {
              max={100}
              id={idString}
              className="form-control" 
-             onChange={(e) => dispatch(updateProposedPanel({...proposedPanel, [color]: e.target.value/100}))}
-             value={value}/>
+             onChange={(e) => {
+              setColorValue(e.target.value);
+              callUpdateProposal(dispatch, proposedPanel, colorName, e);
+             }}
+             value={colorValue}/>
       <input type="number" 
             min={0} 
             max={100} 
             id={idString} 
             className="form-control" 
-            onChange={(e) => dispatch(updateProposedPanel({...proposedPanel, [color]: e.target.value/100}))}
-            value={value}/>
+            onChange={(e) => {
+              setColorValue(e.target.value);
+              callUpdateProposal(dispatch, proposedPanel, colorName, e);
+            }}
+            value={colorValue}/>
     </div>
   );
 }
@@ -54,7 +74,7 @@ function PanelSettingsBody({proposedPanel, dispatch}) {
             <label htmlFor="panelName" className="form-label">Panel Name</label>
             <input type="text" 
                     id="panelName" 
-                    className="form-control" 
+                    className="form-control"
                     value={proposedPanel['name']} 
                     onChange={(e) => dispatch(updateProposedPanel({...proposedPanel, name:e.target.value}))}/>
           </div> 
@@ -62,7 +82,7 @@ function PanelSettingsBody({proposedPanel, dispatch}) {
             <label htmlFor="panelGroup" className="form-label">Panel Group</label>
             <input type="text" 
                     id="panelGroup" 
-                    className="form-control" 
+                    className="form-control"
                     value={proposedPanel['group']} 
                     onChange={(e) => dispatch(updateProposedPanel({...proposedPanel, group:e.target.value}))}/>
           </div> 
@@ -71,7 +91,7 @@ function PanelSettingsBody({proposedPanel, dispatch}) {
               <label htmlFor="macAddress" className="form-label">Mac Address</label>
               <input type="text" 
                       id="macAddress" 
-                      className="form-control" 
+                      className="form-control smaller-font"
                       value={formatMacAddress(proposedPanel['macAddr'])} 
                       disabled={true} />
             </div> 
@@ -79,7 +99,7 @@ function PanelSettingsBody({proposedPanel, dispatch}) {
               <label htmlFor="softwareVersion" className="form-label">Software Version</label>
               <input type="text" 
                       id="softwareVersion" 
-                      className="form-control" 
+                      className="form-control smaller-font"
                       value={proposedPanel['version']} 
                       disabled={true} />
             </div>
@@ -87,17 +107,17 @@ function PanelSettingsBody({proposedPanel, dispatch}) {
               <label htmlFor="ipAddr" className="form-label">IP Address</label>
               <input type="text" 
                       id="ipAddr" 
-                      className="form-control" 
+                      className="form-control smaller-font"
                       value={proposedPanel['ipAddr']} 
                       disabled={true} />
             </div>
           </div>
           <div className='row'>
-            <ColorField color='red' proposedPanel={proposedPanel} dispatch={dispatch} />
-            <ColorField color='green'proposedPanel={proposedPanel} dispatch={dispatch} />
-            <ColorField color='blue' proposedPanel={proposedPanel} dispatch={dispatch} />
-            <ColorField color='white' proposedPanel={proposedPanel} dispatch={dispatch} />
-            <ColorField color='fan' proposedPanel={proposedPanel} dispatch={dispatch} />
+            <ColorField colorName='red' proposedPanel={proposedPanel} dispatch={dispatch} />
+            <ColorField colorName='green'proposedPanel={proposedPanel} dispatch={dispatch} />
+            <ColorField colorName='blue' proposedPanel={proposedPanel} dispatch={dispatch} />
+            <ColorField colorName='white' proposedPanel={proposedPanel} dispatch={dispatch} />
+            <ColorField colorName='fan' proposedPanel={proposedPanel} dispatch={dispatch} />
           </div>
         </form> 
       </div>

--- a/frontend/src/state/actions.js
+++ b/frontend/src/state/actions.js
@@ -1,4 +1,5 @@
 export const stateTreeLoaded = "init/loadStateTree";
+export const shadowTreeLoaded = "init/loadShadowTree";
 export const doEditGroup = "group/edit";
 export const doEditPanel = "panel/edit";
 export const doUpdateProposedGroup = "group/updateProposal";

--- a/frontend/src/state/reducer.js
+++ b/frontend/src/state/reducer.js
@@ -1,6 +1,12 @@
-import { stateTreeLoaded, doEditGroup, doEditPanel
+import { stateTreeLoaded, shadowTreeLoaded, doEditGroup, doEditPanel
        , doUpdateProposedGroup, doUpdateProposedPanel, doApplyProposedPanel } from "./actions";
-import { getStateTree, applyProposedPanelConfig } from '../api.js';
+import { getShadowTree, getStateTree, applyProposedPanelConfig } from '../api.js';
+
+export async function loadShadowTree(dispatch, getState) {
+  const response = await getShadowTree();
+  // Load the state tree.
+  dispatch({ type: shadowTreeLoaded, payload: response });
+}
 
 export async function loadStateTree(dispatch, getState) {
   const response = await getStateTree();
@@ -26,7 +32,9 @@ export function updateProposedPanel(newProposal) {
 
 export async function applyProposedPanel(dispatch, getState) {
   const state = getState();
-  applyProposedPanelConfig(state['editedPanel'], state['proposedPanel']);
+  // Update the panel, then grab the updated state to refresh the UI.
+  applyProposedPanelConfig(state['editedPanel'], state['proposedPanel'])
+      .then(loadShadowTree(dispatch, getState));
   dispatch({ type: doApplyProposedPanel });
 }
 
@@ -42,6 +50,9 @@ export default function appReducer(state=defaultState, action) {
   switch (action.type) {
     case stateTreeLoaded: {
       return { ...state, statetree: action.payload };
+    }
+    case shadowTreeLoaded: {
+      return { ...state, shadowtree: action.payload };
     }
     case doEditGroup: { 
       return { ...state, editedGroup: action.payload, proposedGroup: {...action.payload} };

--- a/server/panel_dashboard/rest/panels.py
+++ b/server/panel_dashboard/rest/panels.py
@@ -1,10 +1,9 @@
 from collections import defaultdict
-from ipaddress import ip_address
 from panel_dashboard.flask_app import app
 import panel_dashboard.state.actions as state_actions
 from flask import jsonify, request
 from panel_dashboard.ops import group_average
-import panel_dashboard.panel_api as panel_api
+
 
 @app.route('/api/v1/statetree', methods=['GET'])
 def panel_statetree__get():
@@ -15,6 +14,17 @@ def panel_statetree__get():
         group = status['group']
         state_tree[group][panel] = status
     return jsonify(state_tree)
+
+
+@app.route('/api/v1/shadowtree', methods=['GET'])
+def panel_shadowtree__get():
+    panels = state_actions.get_panels()
+    shadow_tree = defaultdict(dict)
+    for panel in panels:
+        status = state_actions.get_shadow(panel)
+        group = status['group']
+        shadow_tree[group][panel] = status
+    return jsonify(shadow_tree)
 
 
 @app.route('/api/v1/group', methods=['GET'])


### PR DESCRIPTION
The performance of the color sliders on mobile was not good. It was generating tens of events per second and synchronizing those with the redux state of the proposed new panel state.

Now the state of the sliders uses react's `useState` hook for performance and smooth sliding and synchronizes to the panel state by debouncing the event stream and dispatching a final redux state update on the trailing edge of the debounced stream of slider events.

This worked very well, but led to another non-intuitive behavior - the state of the panel wasn't immediately reflected in the UI after saving new state. This was because the app was synchronized to the known panel states, not the panel "shadow" desired states. Basically it was pulling the panel state before the panel had time to update. 

The solution was to reconfigure the UI to display the panel "shadow" desired state and rely on the server to eventually get the panel's synced to the shadow. It's a much better workflow. 