### PR TITLE
Async Support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "./.data/redis:/data"
 
   server:
-    build: 
+    build:
       context: .
     image: ${SERVER_IMG_NAME}:latest
     volumes:
@@ -14,21 +14,20 @@ services:
       PYTHONDONTWRITEBYTECODE: "1"
       FLASK_DEBUG: "1"
       DISCOVERY_MODE: "ip_list"
-      PANEL_IPS: "192.168.1.194,192.168.1.180,192.168.1.148,192.168.1.118,192.168.1.115,192.168.1.103,192.168.1.148,192.168.1.192"
+      PANEL_IPS: "192.168.1.194,192.168.1.180,192.168.1.148,192.168.1.118,192.168.1.115,192.168.1.103,192.168.1.192,192.168.1.116,192.168.1.144,192.168.1.147"
       REDIS_HOST_PORT: "redis:6379"
     ports:
       - "5000:5000"
 
   worker:
-    build: 
+    build:
       context: .
     volumes:
       - "./server/panel_dashboard:/app/panel_dashboard"
     environment:
       PYTHONDONTWRITEBYTECODE: "1"
       DISCOVERY_MODE: "ip_list"
-      PANEL_IPS: "192.168.1.194,192.168.1.180,192.168.1.148,192.168.1.118,192.168.1.115,192.168.1.103,192.168.1.148,192.168.1.192"
+      PANEL_IPS: "192.168.1.194,192.168.1.180,192.168.1.148,192.168.1.118,192.168.1.115,192.168.1.103,192.168.1.192,192.168.1.116,192.168.1.144,192.168.1.147"
       REDIS_HOST_PORT: "redis:6379"
     command: ["start_worker.sh"]
-      
-    
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,7 @@ import './App.css';
 import Navbar from './modules/navbar/Navbar';
 
 import { useDispatch } from 'react-redux';
-import { loadShadowTree, loadStateTree } from './state/reducer';
+import { loadShadowTree } from './state/reducer';
 import PanelGroupList from './modules/group_list/GroupList';
 import PanelSettingsModal from './modules/panel_settings/PanelSettingsModal';
 import GroupSettingsModal from './modules/panel_settings/GroupSettingsModal';
@@ -10,8 +10,6 @@ import GroupSettingsModal from './modules/panel_settings/GroupSettingsModal';
 function App() {
   const dispatch = useDispatch();
   loadShadowTree(dispatch);
-  loadStateTree(dispatch);
-
 
   return (
     <div className="App">

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -9,7 +9,7 @@ if (isDevlopmentMode()) {
 }
 
 const _LOCAL_BACKEND = "http://localhost:5000";
-const _PRODUCTION_BACKEND = window.location.origin; 
+const _PRODUCTION_BACKEND = window.location.origin;
 
 function getBackendUrl() {
   if (isDevlopmentMode() ) {
@@ -28,7 +28,7 @@ function fetchPOST(uri, data) {
                     , mode: 'cors'
                     , cache: 'no-cache'
                     , headers: { 'Content-Type': 'application/json'}
-                    , body: JSON.stringify(data) 
+                    , body: JSON.stringify(data)
                     });
 }
 
@@ -38,10 +38,6 @@ function makeApiEndpoint(target) {
 
 export function getShadowTree() {
   return fetchGET(makeApiEndpoint("shadowtree"));
-}
-
-export function getStateTree() {
-  return fetchGET(makeApiEndpoint("statetree"));
 }
 
 export function applyProposedPanelConfig(previousPanelConfig, proposedPanelConfig) {

--- a/frontend/src/modules/group_list/GroupList.js
+++ b/frontend/src/modules/group_list/GroupList.js
@@ -14,7 +14,7 @@ function Panel(panelConfig, panelIP, dispatch) {
             <div> Panel Name: <b> {panelName} </b></div>
             <div> IP: <b> {panelIP} </b></div>
           </div>
-          <button className='btn btn-secondary panel-settings-btn' 
+          <button className='btn btn-secondary panel-settings-btn'
                   type="button"
                   onClick={() => dispatch(editPanel(panelConfig))}
                   data-bs-toggle="modal"
@@ -24,7 +24,7 @@ function Panel(panelConfig, panelIP, dispatch) {
           </button>
         </div>
       </div>
-    </div> 
+    </div>
   );
 }
 
@@ -37,7 +37,7 @@ function PanelGroup(groupConfig, groupName, dispatch) {
           <div>
             {`Panel Group: ${groupName}`}
           </div>
-          <div className="btn btn-secondary group-settings-btn" 
+          <div className="btn btn-secondary group-settings-btn"
                data-bs-toggle="modal"
                data-bs-target="#group-settings-modal"
                onClick={() => dispatch(editGroup(getGroupSummary(groupConfig)))}

--- a/frontend/src/state/actions.js
+++ b/frontend/src/state/actions.js
@@ -1,4 +1,3 @@
-export const stateTreeLoaded = "init/loadStateTree";
 export const shadowTreeLoaded = "init/loadShadowTree";
 export const doEditGroup = "group/edit";
 export const doEditPanel = "panel/edit";

--- a/server/panel_dashboard/constants.py
+++ b/server/panel_dashboard/constants.py
@@ -1,4 +1,5 @@
 import os
+import httpx
 
 
 # Convert the redis host and port to a base url.
@@ -8,3 +9,9 @@ _REDIS_URL = f"redis://{os.environ.get('REDIS_HOST_PORT')}"
 REDIS_STATE_BACKEND_URL = f"{_REDIS_URL}/0"
 # Celery message broker gets Redis DB 1
 REDIS_CELERY_BROKER_URL = f"{_REDIS_URL}/1"
+
+# How long to wait for http requests.
+HTTP_TIMEOUT_S = 5
+
+# An http client supporting async calls to be shared across requests
+HTTP_CLIENT = httpx.AsyncClient(timeout=HTTP_TIMEOUT_S)

--- a/server/panel_dashboard/ops/synchronize_state.py
+++ b/server/panel_dashboard/ops/synchronize_state.py
@@ -1,23 +1,38 @@
 import panel_dashboard.panel_api as panel_api
 
-def sync_panel(current, desired):
-    previous_panel_config = current 
-    new_panel_config = desired 
+
+def _is_close(a, b, tolerance=0.005):
+    """
+    Since the UI works in integers from 1 to 100 but the ESP32 PWM
+    has a resolution of 1024, some values we will try to set will
+    be approximately correct, and that's just fine. We need
+    a function to check if things are approximately equal, or "close".
+
+    Setting a tolerance of 0.005 would verify things are accurate to within
+    1/2 a percent for a value of 1 to 100. That's plenty for this application.
+    """
+
+    return abs(a - b) < tolerance
+
+
+async def sync_panel(current, desired):
+    previous_panel_config = current
+    new_panel_config = desired
     ip_addr = current['ipAddr']
 
     # Update the color
     for color in ('red', 'green', 'blue', 'white'):
-        if previous_panel_config[color] != new_panel_config[color]:
+        if not _is_close(previous_panel_config[color], new_panel_config[color]):
             value = new_panel_config[color]
-            panel_api.color.set_panel_color(ip_addr, color, value)
+            await panel_api.color.set_panel_color(ip_addr, color, value)
 
     # Update the name/group
     for ident in ('name', 'group'):
         if previous_panel_config[ident] != new_panel_config[ident]:
             value = new_panel_config[ident]
-            panel_api.ident.set_ident(ip_addr, ident, value)
+            await panel_api.ident.set_ident(ip_addr, ident, value)
 
     # Update the fan speed
-    if previous_panel_config['fan'] != new_panel_config['fan']:
+    if not _is_close(previous_panel_config['fan'], new_panel_config['fan']):
         value = new_panel_config['fan']
-        panel_api.fan.set_fan_pct(ip_addr, value)
+        await panel_api.fan.set_fan_pct(ip_addr, value)

--- a/server/panel_dashboard/panel_api/color.py
+++ b/server/panel_dashboard/panel_api/color.py
@@ -1,21 +1,34 @@
-import requests
+import logging
+import httpx
 from panel_dashboard.ops.calibration import pct_to_duty_cycle
+from panel_dashboard.constants import HTTP_CLIENT
+
+_logger = logging.getLogger(__name__)
 
 _VALID_COLORS = ['red', 'green', 'blue', 'white']
-def set_panel_color(ip_addr, color_name, color_value):
+async def set_panel_color(ip_addr, color_name, color_value, retries=2):
     color_name = color_name.lower()
     assert color_name in _VALID_COLORS
     duty_cycle = pct_to_duty_cycle(color_name, color_value)
-    requests.post(f"http://{ip_addr}/{color_name}", json={color_name: duty_cycle})
+    try:
+        await HTTP_CLIENT.post(f"http://{ip_addr}/{color_name}", json={color_name: duty_cycle})
+    except httpx.ConnectTimeout:
+        if retries > 0:
+            _logger.warning(f"Connect Error on {ip_addr} for {color_name}={color_value}. Retrying...")
+            return await set_panel_color(ip_addr, color_name, color_value, retries=retries-1)
+        else:
+            _logger.error(f"Failed to connect to {ip_addr} for {color_name}={color_value}.")
+            raise
 
-def set_panel_red_pct(ip_addr, value):
-    set_panel_color(ip_addr, "red", value)
 
-def set_panel_green_pct(ip_addr, value):
-    set_panel_color(ip_addr, "green", value)
+async def set_panel_red_pct(ip_addr, value):
+    await set_panel_color(ip_addr, "red", value)
 
-def set_panel_blue_pct(ip_addr, value):
-    set_panel_color(ip_addr, "blue", value)
+async def set_panel_green_pct(ip_addr, value):
+    await set_panel_color(ip_addr, "green", value)
 
-def set_panel_white_pct(ip_addr, value):
-    set_panel_color(ip_addr, "white", value)
+async def set_panel_blue_pct(ip_addr, value):
+    await set_panel_color(ip_addr, "blue", value)
+
+async def set_panel_white_pct(ip_addr, value):
+    await set_panel_color(ip_addr, "white", value)

--- a/server/panel_dashboard/panel_api/fan.py
+++ b/server/panel_dashboard/panel_api/fan.py
@@ -1,6 +1,6 @@
-import requests
-from panel_dashboard.ops.calibration import duty_cycle_to_pct, pct_to_duty_cycle
+from panel_dashboard.ops.calibration import pct_to_duty_cycle
+from panel_dashboard.constants import HTTP_CLIENT
 
-def set_fan_pct(ip_addr, speed):
+async def set_fan_pct(ip_addr, speed):
     duty_cycle = pct_to_duty_cycle('fan', speed)
-    requests.post(f"http://{ip_addr}/fan", json={"fan": duty_cycle})
+    await HTTP_CLIENT.post(f"http://{ip_addr}/fan", json={"fan": duty_cycle})

--- a/server/panel_dashboard/panel_api/ident.py
+++ b/server/panel_dashboard/panel_api/ident.py
@@ -1,10 +1,10 @@
-import requests
+from panel_dashboard.constants import HTTP_CLIENT
 
-def set_ident(ip_addr, ident, value):
-    requests.post(f"http://{ip_addr}/{ident}", json={ident: value})
+async def set_ident(ip_addr, ident, value):
+    await HTTP_CLIENT.post(f"http://{ip_addr}/{ident}", json={ident: value})
 
-def set_name(ip_addr, name):
-    set_ident(ip_addr, 'name', name)
+async def set_name(ip_addr, name):
+    await set_ident(ip_addr, 'name', name)
 
-def set_group(ip_addr, group):
-    set_ident(ip_addr, 'group', group)
+async def set_group(ip_addr, group):
+    await set_ident(ip_addr, 'group', group)

--- a/server/panel_dashboard/panel_api/status.py
+++ b/server/panel_dashboard/panel_api/status.py
@@ -1,15 +1,14 @@
-import os
-import requests
+import typing
 import panel_dashboard.ops.calibration as calibration
+from panel_dashboard.constants import HTTP_CLIENT
 
-_STATUS_TIMEOUT_S = int(os.environ.get('STATUS_TIMEOUT_S', '3'))
-
-def get_panel_status(ip_addr):
-    status = requests.get(f"http://{ip_addr}/status", timeout=_STATUS_TIMEOUT_S).json()
-    status['red'] = calibration.duty_cycle_to_pct('red', status['redDutyCycle']) 
-    status['green'] = calibration.duty_cycle_to_pct('green', status['greenDutyCycle']) 
-    status['blue'] = calibration.duty_cycle_to_pct('blue', status['blueDutyCycle']) 
-    status['white'] = calibration.duty_cycle_to_pct('white', status['whiteDutyCycle']) 
-    status['fan'] = calibration.duty_cycle_to_pct('fan', status['fanDutyCycle']) 
+async def get_panel_status(ip_addr) -> dict[str, typing.Any]:
+    status_result = await HTTP_CLIENT.get(f"http://{ip_addr}/status")
+    status = status_result.json()
+    status['red'] = calibration.duty_cycle_to_pct('red', status['redDutyCycle'])
+    status['green'] = calibration.duty_cycle_to_pct('green', status['greenDutyCycle'])
+    status['blue'] = calibration.duty_cycle_to_pct('blue', status['blueDutyCycle'])
+    status['white'] = calibration.duty_cycle_to_pct('white', status['whiteDutyCycle'])
+    status['fan'] = calibration.duty_cycle_to_pct('fan', status['fanDutyCycle'])
     status['ipAddr'] = ip_addr
     return status

--- a/server/panel_dashboard/rest/groups.py
+++ b/server/panel_dashboard/rest/groups.py
@@ -2,25 +2,37 @@ from flask import jsonify, request
 from panel_dashboard.flask_app import app
 import panel_dashboard.state.actions as state_actions
 from panel_dashboard.ops import group_average
+import asyncio
 
 
 @app.route("/api/v1/group", methods=["GET"])
-def group__get():
+async def group__get():
     group_name = request.args["name"]
     panels = state_actions.get_panels()
     panel_statuses = [state_actions.get_status(x) for x in panels]
     group_panels = [x for x in panel_statuses if x["group"] == group_name]
 
     to_return = group_average.average_panels(group_panels)
-    to_return["name"] = group_name 
+    to_return["name"] = group_name
 
     return jsonify(to_return)
 
 
 @app.route("/api/v1/group", methods=["POST"])
-def group__post():
+async def group__post():
+    """
+    Apply the proposed configuration to any selected panels
+
+    Note that while a configuration option may appear unchanged
+    between the previous config and the proposed config, this is
+    misleading. The proposal is an average of all panels, so
+    a POST to this endpoint should apply that "average" to all
+    panels in the group bringing a heterogenous state into a
+    homogenous state.
+    """
     config = request.get_json()
-    previous_config = config['previousGroupConfig']
+    # This is available from the frontend, but not really needed right now.
+    #previous_config = config['previousGroupConfig']
     proposed_config = config['proposedGroupConfig']
     group_name = proposed_config["group"]
 
@@ -28,12 +40,19 @@ def group__post():
     panel_statuses = [state_actions.get_status(x) for x in panels]
     group_panels = [x for x in panel_statuses if x["group"] == group_name]
 
-    changed_keys = [k for k in proposed_config if previous_config[k] != proposed_config[k]]
-    changes = {k:v for k, v in proposed_config.items() if k in changed_keys}
+    to_await = []
 
     for panel in group_panels:
         current_shadow = state_actions.get_shadow(panel['ipAddr'])
-        new_shadow = current_shadow | changes
-        state_actions.set_shadow(panel['ipAddr'], new_shadow)
+        # There are things in the proposed group config that don't belong in
+        # individual panel config (such as the number of panels in the group).
+        # This filter makes sure we synchronize state that makes sense for a
+        # panel.
+        applicable_config = {k:v for k,v in proposed_config.items() if k in current_shadow}
+        new_shadow = current_shadow | applicable_config
+        to_await.append(state_actions.set_shadow(panel['ipAddr'], new_shadow))
 
-    return jsonify(proposed_config) 
+    # This way we can asynchronously set all the panels' statuses.
+    await asyncio.gather(*to_await)
+
+    return jsonify(proposed_config)

--- a/server/panel_dashboard/rest/panels.py
+++ b/server/panel_dashboard/rest/panels.py
@@ -5,7 +5,7 @@ from flask import jsonify, request
 
 
 @app.route('/api/v1/statetree', methods=['GET'])
-def panel_statetree__get():
+async def panel_statetree__get():
     panels = state_actions.get_panels()
     state_tree = defaultdict(dict)
     for panel in panels:
@@ -16,7 +16,7 @@ def panel_statetree__get():
 
 
 @app.route('/api/v1/shadowtree', methods=['GET'])
-def panel_shadowtree__get():
+async def panel_shadowtree__get():
     panels = state_actions.get_panels()
     shadow_tree = defaultdict(dict)
     for panel in panels:
@@ -27,13 +27,13 @@ def panel_shadowtree__get():
 
 
 @app.route('/api/v1/panel', methods=['POST'])
-def panel__post():
+async def panel__post():
     new_config = request.get_json()
     # Not sure this is actually needed, since the IP uniquely identifies the panel.
     new_panel_config = new_config['proposedPanelConfig']
     ip_addr = new_panel_config['ipAddr']
 
     # Update our state
-    state_actions.set_shadow(ip_addr, new_panel_config)
-    
+    await state_actions.set_shadow(ip_addr, new_panel_config)
+
     return jsonify(new_panel_config)

--- a/server/panel_dashboard/task/celeryconfig.py
+++ b/server/panel_dashboard/task/celeryconfig.py
@@ -1,13 +1,15 @@
-import os
 from panel_dashboard.constants import REDIS_CELERY_BROKER_URL
 
 broker_url = REDIS_CELERY_BROKER_URL
 imports = ('panel_dashboard.task.periodic',)
 
+# This is the default, but explicitly setting it silences a warning.
+broker_connection_retry_on_startup = True
+
 _SECOND = 1.0
 _DISCOVER_PANEL_QUERY_INTERVAL = 30 * _SECOND
 
-beat_schedule = { 
+beat_schedule = {
     'refresh_panel_list': {
         'task': 'panel_dashboard.task.periodic.discover_panels',
         'schedule': _DISCOVER_PANEL_QUERY_INTERVAL,

--- a/server/panel_dashboard/task/periodic.py
+++ b/server/panel_dashboard/task/periodic.py
@@ -1,17 +1,29 @@
-from requests.exceptions import ConnectionError
+import asyncio
+from httpx import ConnectError
+from asgiref.sync import async_to_sync
 from panel_dashboard.celery_app import app
-from panel_dashboard.discovery.panel_discovery import discover_panel_ips 
+from panel_dashboard.discovery.panel_discovery import discover_panel_ips
 from panel_dashboard.panel_api.status import get_panel_status
 from panel_dashboard.state.actions import confirm_panel
 
+async def _get_status_and_confirm(panel_ip):
+    # TODO: What happens if panel goes offline?
+    try:
+        status = await get_panel_status(panel_ip)
+        await confirm_panel(panel_ip, status)
+    except ConnectError:
+        # That panel we discovered probably got turned off, so just keep going.
+        pass
+
+
 @app.task
 def discover_panels():
+    results = []
     for panel_ip in discover_panel_ips():
-        try:
-            # TODO: What happens if panel goes offline?
-            # Get the status of all current panels
-            status = get_panel_status(panel_ip)
-            confirm_panel(panel_ip, status)
-        except ConnectionError:
-            # That panel we discovered probably got turned off, so just keep going.
-            continue
+        # Get the status of all current panels. This implicitly synchronizes
+        # the state of the panel with the state in the backing store.
+        results.append(_get_status_and_confirm(panel_ip))
+
+    # TODO: Celery 6.0 might support async directly. For now, we need
+    # to use asgiref to interop celery to the async stuff.
+    async_to_sync(asyncio.gather)(*results)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,7 @@
-flask
+flask[async]
 flask-cors
 celery[redis]
 redis
 zeroconf
-requests
+httpx
+asgiref


### PR DESCRIPTION
The main feature here is a switch to use `flask[async]`, which has the benefit of doing non-blocking updates for batch changes for a panel group. This eliminates the effect of each panel update popping into effect one at a time and makes it more "instantaneous" since waiting on panels to respond to update requests is slow, while making update requests is very fast. We can make 10 requests faster than 1 panel can respond to a request. 

Unfortunately, celery doens't support async at this time, so we have to use the `asgiref` library to interop between celery tasks and the panel library that is now async.